### PR TITLE
Allow override of lookup env

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/kelseyhightower/envconfig
+module github.com/offen/envconfig


### PR DESCRIPTION
PR to source repo: https://github.com/kelseyhightower/envconfig/pull/210

offen/docker-volume-backup will use this fork until the PR gets merged to the source repo.
Source repo seems inactive since ~3 years, though.